### PR TITLE
fix server crashing on creeper explosion

### DIFF
--- a/CreeperConfetti/src/main/java/com/sr2610/creeperconfetti/ConfettiHandler.java
+++ b/CreeperConfetti/src/main/java/com/sr2610/creeperconfetti/ConfettiHandler.java
@@ -47,7 +47,7 @@ public class ConfettiHandler {
 					if (rand.nextInt(100) < 5)
 						creeper.world.playSound(creeper.posX, creeper.posY, creeper.posZ, ModSounds.confetti, SoundCategory.HOSTILE,2F,1F, false);
 					creeper.world.playSound(creeper.posX, creeper.posY, creeper.posZ,SoundEvents.ENTITY_FIREWORK_ROCKET_TWINKLE, SoundCategory.HOSTILE, 1F,1F, false);		
-					if(!creeper.world.isRemote)
+					if(creeper.world.isRemote)
 					spawnParticles(creeper);
 					creeper.remove(); // Removes the creeper from the world, as if it was dead
 				} else {


### PR DESCRIPTION
The condition is wrong. See: https://mcforge.readthedocs.io/en/latest/concepts/sides/#worldisremote “if [world.isRemote] is true, the world is currently running on the logical client. If the field is false, the world is running on the logical server.”